### PR TITLE
ACM-14143: Add RHACS integration dev-preview

### DIFF
--- a/dev-preview/README.md
+++ b/dev-preview/README.md
@@ -21,6 +21,7 @@ Features on Development Preview
 - [Edge Management](#edge-management)
   - [Installation](#installation-3)
   - [Usage](#usage-3)
+- [Global Hub Integration with Red Hat Advanced Cluster Security](#global-hub-integration-with-red-hat-advanced-cluster-security)
 
 ## Ansible Collection & Inventory Plugin
 
@@ -96,6 +97,14 @@ Installation instructions can be found in the [repo](https://github.com/flightct
 ### Usage
 
 Instructions for managing fleets can be found [here](https://github.com/flightctl/flightctl/blob/main/docs/user/managing-fleets.md) while for managing devices are available [here](https://github.com/flightctl/flightctl/blob/main/docs/user/managing-devices.md). One of the benefits of using Edge Management together with ACM is the ability to enroll devices running Red Hat Device Edge seamlessly.
+
+## Global Hub Integration with Red Hat Advanced Cluster Security
+
+This feature adds to the Global Hub the capability to aggregate data from the
+Red Hat Advanced Cluster Security instances that run in the managed hubs. The
+aggregated data is available in a new _Security Violations_ dashboard. For more
+details and configuration instructions see the Global Hub documentation
+[here](https://github.com/stolostron/multicluster-global-hub/blob/main/doc/dev-preview.md#enable-rhacs-integration).
 
 # Graduated features
 


### PR DESCRIPTION
This patch adds to the dev-preview document a reference to the document that describes the integration between the global hub and Red Hat Advandced Cluster Security.

Related: https://issues.redhat.com/browse/ACM-14143
Related: https://issues.redhat.com/browse/MGMT-18591
Related: https://github.com/stolostron/multicluster-global-hub/blob/main/doc/dev-preview.md#enable-rhacs-integration